### PR TITLE
Fix issue with timezone incorrectly parsed as year

### DIFF
--- a/lib/Date/Parse/Modern.pm
+++ b/lib/Date/Parse/Modern.pm
@@ -262,7 +262,7 @@ sub strtotime {
 
 	# The year may be on the end of the string: Sat May  8 21:24:31 2021
 	if (!$year) {
-		($year) = $str =~ m/\b(\d{4})\b/;
+		($year) = $str =~ m/\b((?<![+-])\d{4})\b/;
 	}
 
 	# Match 1st, 2nd, 3rd, 29th


### PR DESCRIPTION
If the input string contains only a time (without a date), and a four-digit timezone offset, the module incorrectly takes the digits of that offset to be the intended year.

This commit fixes that issue by insuring that the four digits the module believes to be a year do not contain a + or - before them.